### PR TITLE
Improve Power (^) Scanning / Add X_SQRT()

### DIFF
--- a/XXLS.php
+++ b/XXLS.php
@@ -420,7 +420,7 @@ class XXLS {
 
 			$j = ( $exp ? 0 - $i : $i );
 
-			if( !$data && $equat[$init_pos - $j] != ' ' ) {
+			if( !$data && !preg_match('/\s/', $equat[$init_pos - $j]) ) {
 				$data = array( 'pos' => $init_pos - $j, 'char' => $equat[$init_pos - $j], 'index' => $index );
 			}
 
@@ -587,6 +587,10 @@ class XXLS_METHODS {
 	
 	static function X_CEILING( $val, $sig = 1 ) {
 		return ceil( $val / $sig ) * $sig;
+	}
+
+	static function X_SQRT( $val ) {
+		return sqrt($val);
 	}
 
 }


### PR DESCRIPTION
- ignore all white space characters when seaching for the base or exponent
  in get_local_exp_part()
- add square root (X_SQRT()) to the available Excel methods
## Reasons For Changes

I came across a formula that was not evaluating properly 

```
=(0.66*M2*(P2^4)*Q2*1/$H$3^2)*(SQRT(1+0.78*(($H$3*Q2/P2^2)^2))-1)
```

`P2^4` and `P2^2` were not finding the BASE of the Power function, however `($H$3*Q2/P2^2)^2` was finding the BASE.  It seemed that only if the BASE was surrounded by parentheses [ ( ) ] would `get_local_exp_part()` find it.  

The function `get_local_exp_part()` seemed to run after the Excel formula was mostly expanded, so when not surrounded by parentheses [ ( ) ] the BASE of the Power function was on the previous line.  In order to find the BASE, `get_local_exp_part()` needed to ignore NEWLINE characters.

`X_SQRT()` is self explanatory.
