### PR TITLE
PHP 5.2 Support and Misc. Bug Fixes

### DIFF
--- a/XXLS.php
+++ b/XXLS.php
@@ -230,9 +230,9 @@ class XXLS {
 
 		$debug_tab = $this->debug ? str_repeat("\t", $depth) : '';
 
-		$expanded_formula = $formula;
+		$default_formula  = "RC";
+		$expanded_formula = $formula ? $formula : $default_formula;
 		$expanded_formula = self::ms_string($expanded_formula);
-		if ( $expanded_formula == "" ) { $expanded_formula = "RC"; } // make sure staticvals get set
 
 		$RANGE = '/(((?:(?P<sheet>[A-Z]{1,})!|\'(?P<sheet2>[A-Z ()]+)\'!)?R((\[(?P<rowrel>-?\d+)\])|(?P<rowabs>\d+))?C((\[(?P<colrel>-?\d+)\])|(?P<colabs>\d+))?):(R((\[(?P<rowrel2>-?\d+)\])|(?P<rowabs2>\d+))?C((\[(?P<colrel2>-?\d+)\])|(?P<colabs2>\d+))?))/i';
 


### PR DESCRIPTION
Most changes are explained well enough in the commit.  The only thing I wanted to clarify was the default formula added to expand_eq().

While I was debugging I noticed that some cells returned NULL even though they contained values.  I discovered that the  cells returning correctly had been previously used in a formula and their values where saved in 'staticvals'.  In order to ensure a cell would return it's contained value, I added a default formula pointing to the current cell.  That way the cell's value would be added to 'staticvals' and returned if a formula wasn't given.
